### PR TITLE
Fix deprecation warning (include is deprecated) Fix #10

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
 - name: CONSUL_TEMPLATE | Install
-  include: install.yml
+  include_tasks: install.yml
   tags:
     - consul_template_install
 
 - name: CONSUL_TEMPLATE | Configure
-  include: config.yml
+  include_tasks: config.yml
   tags:
     - consul_template_configure
 
 - name: CONSUL_TEMPLATE | Service
-  include: service.yml
+  include_tasks: service.yml
   tags:
     - consul_template_service


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR fix deprecation warning about include

```
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature 
will be removed in version 2.16.
```


### Benefits

<!-- What benefits will be realized by the code change? -->

Playbook maintenance up to [new ansible core 2.12.0](https://github.com/ansible/ansible/blob/v2.12.0/changelogs/CHANGELOG-v2.12.rst)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

#10 